### PR TITLE
Add redis_subscriber:Auth(), add error class and redis.IsError(), and fix returned table indices and nil values

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -68,6 +68,9 @@ GMOD_MODULE_OPEN( )
 	LUA->PushCFunction( redis_subscriber::Create );
 	LUA->SetField( -2, "CreateSubscriber" );
 
+	LUA->PushCFunction( redis_client::IsError );
+	LUA->SetField( -2, "IsError" );
+
 	LUA->SetField( GarrysMod::Lua::INDEX_GLOBAL, redis::table_name );
 
 	return 0;

--- a/source/redis_client.hpp
+++ b/source/redis_client.hpp
@@ -16,5 +16,5 @@ namespace redis_client
 void Initialize( GarrysMod::Lua::ILuaBase *LUA );
 void Deinitialize( GarrysMod::Lua::ILuaBase *LUAe );
 LUA_FUNCTION_DECLARE( Create );
-
+LUA_FUNCTION_DECLARE( IsError );
 }


### PR DESCRIPTION
Added `redis_subscriber:Auth(password)` so you can have a password on your Redis server.

In client callbacks, errors are now returned as a `redis_clienterror` instead of a string, so you can tell whether something is actually an error or if it's just the stored string text. `redis.IsError()` checks if it is an error and `tostring` gets the message.

Fixed returned tables having zero based indexes, and also changed null values from nil to false, so the table will always have the correct number of values with no gaps. So you can use `ipairs` or whatever.

